### PR TITLE
Optimize ArrayList.removeWhere() to do less copying

### DIFF
--- a/source/ceylon/collection/ArrayList.ceylon
+++ b/source/ceylon/collection/ArrayList.ceylon
@@ -362,8 +362,8 @@ shared serializable class ArrayList<Element>
     shared actual Integer removeWhere(
         Boolean selecting(Element&Object element)) {
         variable value i=0;
-        variable value j=size;
-        while (i<size) {
+        variable value j=length;
+        while (i<length) {
             if (exists elem = array[i++]) {
                 if (selecting(elem)) {
                     j=i-1;

--- a/source/ceylon/collection/ArrayList.ceylon
+++ b/source/ceylon/collection/ArrayList.ceylon
@@ -362,7 +362,15 @@ shared serializable class ArrayList<Element>
     shared actual Integer removeWhere(
         Boolean selecting(Element&Object element)) {
         variable value i=0;
-        variable value j=0;
+        variable value j=size;
+        while (i<size) {
+            if (exists elem = array[i++]) {
+                if (selecting(elem)) {
+                    j=i-1;
+                    break;
+                }
+            }
+        }
         while (i<length) {
             if (exists elem = array[i++]) {
                 if (!selecting(elem)) {


### PR DESCRIPTION
In the beginning, as long as `selecting()` returns true, just update `i`&`j` indexes instead of copying elements since the source & destination indexes are the same.

Also add unit tests since there weren't any.